### PR TITLE
fix(GUI) MultiProfileItemGui:init PreHook did not leave space for the quick_profile_panel

### DIFF
--- a/Custom Profile Set/main.lua
+++ b/Custom Profile Set/main.lua
@@ -454,8 +454,8 @@ function CustomProfileSet:SetupHooks()
                         td._panel or
                         panel:panel(
                             {
-                                w = profile_panel_width,
-                                h = 36 + td.quick_panel_h
+                                w = 36 + 5 + profile_panel_width,
+                                h = 36
                             }
                         )
 
@@ -464,8 +464,7 @@ function CustomProfileSet:SetupHooks()
                         td._panel:panel(
                             {
                                 w = profile_panel_width,
-                                h = 36,
-                                y = td.quick_panel_h
+                                h = 36
                             }
                         )
                 end


### PR DESCRIPTION
New calculation of the profile_panel is quick_profile_panel_w + padding + profile_panel_w. This is the same calculation used in their code just with our custom width depending on the characters. The quick profile selector will now be visible again.